### PR TITLE
docs: correct PACSeries Zenodo DOI (series concept, not repo archive)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ See `STANDARDS.md` at workspace root for full spec.
   - Curvature from connection-density gradients, invariant interval from Killing form uniqueness
   - Complete derivation chain: self-loop → phi → PAC → ADE → complement → parallax → Weyl → SEC → Lorentz → ds² → c → proper time
   - 8 predictions (4P+2D+2C), zero M1-M12 contradictions
-- **PACSeries** published on Zenodo (DOI: 10.5281/zenodo.15783623)
+- **PACSeries** published on Zenodo (concept DOI: 10.5281/zenodo.17295102; latest v0.3 = 10.5281/zenodo.21228036)
 - **Active organization effort**: bringing all experiments to full standard, adding FDO source links
 
 ## Do Not

--- a/dawn-field-theory.md
+++ b/dawn-field-theory.md
@@ -9,7 +9,7 @@ The theory does not fit parameters to data. It derives them. The fine structure 
 DFT is an active research program at the Dawn Field Institute. It is not finished. Some results are structural (pass by construction), some predictions have failed (DESI wa), and the framework awaits independent replication and peer review. This document describes what the framework does, what it has produced, and where it stands.
 
 **Author:** Peter Groom, Dawn Field Institute
-**Published papers:** PACSeries v0.2 on Zenodo (DOI: 10.5281/zenodo.15783623)
+**Published papers:** PACSeries v0.3 on Zenodo (concept DOI: 10.5281/zenodo.17295102)
 
 ---
 

--- a/for_ai_labs.md
+++ b/for_ai_labs.md
@@ -101,7 +101,7 @@ The entire codebase is open. The framework invites scrutiny — the Epistemic Co
 
 ## Key Papers
 
-- **PACSeries v0.2** (Zenodo DOI: 10.5281/zenodo.15783623): 6 papers covering the mathematical foundations
+- **PACSeries v0.3** (Zenodo concept DOI: 10.5281/zenodo.17295102): 12 papers. The six foundational papers:
   - Paper 1: Structure Cost of Erasure (Landauer + DPI -> Xi)
   - Paper 2: Balance Constant Decomposition (Xi = gamma + ln(phi))
   - Paper 3: Feigenbaum Constants from Fibonacci Arithmetic (13 digits)

--- a/infodynamics.md
+++ b/infodynamics.md
@@ -92,8 +92,7 @@ Infodynamics does not replace quantum field theory or general relativity. It gro
 - Full non-perturbative calculations (M11 is semi-classical)
 
 ### What's published
-- PACSeries v0.2 on Zenodo (DOI: 10.5281/zenodo.15783623): 6 papers covering erasure cost, Xi decomposition, Feigenbaum constants, Standard Model parameters, classical physics, computational validation
-- v0.3 in planning (incorporates M4-M11 results)
+- PACSeries v0.3 on Zenodo (concept DOI: 10.5281/zenodo.17295102): 12 papers covering erasure cost, Xi decomposition, Feigenbaum constants, Standard Model parameters, classical physics, and computational validation (Papers 1-6), extended to the symmetry primitive, quantum gravity, cosmology, spacetime, quantum mechanics, and observational contact (Papers 7-12)
 
 ---
 


### PR DESCRIPTION
## What
Four docs referenced the PACSeries paper series with DOI `10.5281/zenodo.15783623` — but that DOI is the **repository software archive** (concept `15595182`, titled *dawnfield-institute/dawn-field-theory*), **not** the paper series.

The PACSeries paper series is concept **`10.5281/zenodo.17295102`**:
- v0.1 = `17295103`
- v0.2 = `18743674`
- **v0.3 = `21228036`** (published 2026-07-06, all 12 papers)

## Changed (series references → concept DOI + refreshed v0.2→v0.3 labels)
- `CLAUDE.md`
- `dawn-field-theory.md` (body line — **not** the front-matter `zenodo_doi`)
- `for_ai_labs.md`
- `infodynamics.md`

## Deliberately NOT changed (these correctly cite the *repo* archive)
- `README.md` DOI badge + citation
- `CONTRIBUTION.md` DOI + BibTeX
- `dawn-field-theory.md:203` `zenodo_doi:` front-matter
- `CITATION.cff` (untouched per repo rule)

Verified against the live Zenodo API. Discovered while publishing PACSeries v0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)