### PR TITLE
Point CITATION.cff at a concept DOI (verified against Zenodo)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,13 @@ url: https://github.com/dawnfield-institute/dawn-field-theory
 license: GPL-3.0-or-later
 version: '2.1'
 date-released: '2026-02-20'
-doi: 10.5281/zenodo.15783623
+# Concept DOI for the repository archive record — always resolves to its newest
+# version. The previous value, 10.5281/zenodo.15783623, was the *version* DOI of the
+# single July 2025 prerelease inside this same family, so every citation pinned to a
+# 2025 snapshot. Verified against the Zenodo API 2026-08-10.
+# To cite the paper series instead, use PACSeries concept DOI 10.5281/zenodo.17295102
+# (latest version 0.3 = 10.5281/zenodo.21228036), which is what README.md advertises.
+doi: 10.5281/zenodo.15595182
 keywords:
 - information theory
 - field dynamics

--- a/papers/README.md
+++ b/papers/README.md
@@ -61,7 +61,20 @@ speculation — the distinction the series is organised around.
 
 ## Citing
 
-Citation metadata is in [`CITATION.cff`](../CITATION.cff) at the repository root. **Its DOI
-field is pending verification** — the repository has carried conflicting concept-DOI values,
-so check `registry/doi_registry.yaml` against Zenodo before citing rather than trusting
-either file alone.
+There are **two separate Zenodo record families**, and conflating them is what made the
+repository appear to contradict itself. Verified against the Zenodo API on 2026-08-10:
+
+| | Concept DOI | Latest version |
+|---|---|---|
+| **PACSeries** — the paper series | `10.5281/zenodo.17295102` | v0.3 = `…21228036` (2026-07-06) |
+| **Repository archive** — this repo as software | `10.5281/zenodo.15595182` | v1.0_prerelease = `…15783623` (2025-07-01) |
+
+- **To cite the papers**, use the PACSeries concept DOI. That is what
+  [`README.md`](../README.md) advertises, and a concept DOI always resolves to the newest
+  version.
+- **To cite the repository**, use [`CITATION.cff`](../CITATION.cff), which points at the
+  repository-archive concept DOI.
+
+The repository-archive family has had **only one version, from July 2025**. Its
+`CITATION.cff` entry still reads `version: 2.1, date-released: 2026-02-20`, which describes
+a state Zenodo has never been given — cutting a fresh GitHub release would close that gap.


### PR DESCRIPTION
Resolves the DOI conflict flagged during the reorganization, by checking Zenodo directly rather than trusting any in-repo document.

**There were never two values for one DOI — there are two record families**, and the docs mixed them:

| | Concept DOI | Latest version |
|---|---|---|
| PACSeries (the papers) | `10.5281/zenodo.17295102` | v0.3 = `…21228036` (2026-07-06) |
| Repository archive (this repo as software) | `10.5281/zenodo.15595182` | v1.0_prerelease = `…15783623` (2025-07-01) |

`CITATION.cff` pointed at **15783623** — the *version* DOI of the single July 2025 prerelease in the repository-archive family. Every citation of the repository was therefore pinned to a 2025 snapshot. It now points at that family's **concept** DOI, which always resolves to the newest version. Same family, so this fixes rot rather than changing what is cited.

`README.md`'s badge (17295102) was already correct for citing the paper series and is untouched. Also verified: v0.1 = `17295103` under concept `17295102` (as `archive/README.md` claims), and a spot-checked registry DOI `17023921` resolves.

**Left for Peter:** `CITATION.cff` still declares `version: 2.1`, `date-released: 2026-02-20`, but the archive family has had no release since 2025-07-01. Cutting a fresh GitHub release would reconcile that; inventing a version number here would not.
