### PR TITLE
Add tracked agent skills; retire the dead kronos command surface

### DIFF
--- a/.claude/skills/dft-experiment/SKILL.md
+++ b/.claude/skills/dft-experiment/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: dft-experiment
+description: Create or modify an experiment in dawn-field-theory so it passes the structure validator and records results honestly. Use when adding an experiment, adding scripts or results to one, writing a journal entry, or pre-registering a claim before running it.
+---
+
+# Working on a dawn-field-theory experiment
+
+`STANDARDS.md` is canonical; this is the operational subset plus the traps that have
+actually cost time here.
+
+## Where experiments live
+
+`experiments/{milestones,sidecars,studies}/` — the validator covers these three.
+`experiments/spikes/` is **exempt by definition** (STANDARDS §3): exploratory, no
+structure required, may be promoted later. Do not "fix" a spike into an experiment
+unless you are deliberately promoting it.
+
+Never create an experiment outside those four directories.
+
+## Required structure
+
+```
+experiment_name/
+├── meta.yaml        REQUIRED — experiment root ONLY
+├── README.md        REQUIRED — thesis, status, score, key results, FDO link
+├── SYNTHESIS.md     recommended — cross-connections
+├── core/            reusable modules imported by scripts
+├── scripts/         exp_NN_name.py
+├── results/         exp_NN_name_YYYYMMDD_HHMMSS.json
+└── journals/        YYYY-MM-DD_slug.md
+```
+
+**`meta.yaml` goes at the experiment root and nowhere else.** Not in `core/`, `scripts/`,
+`results/` or `journals/`. 429 subdirectory copies were a CIP artifact and were removed;
+recreating them re-breaks `git log` as a staleness signal.
+
+## meta.yaml has two zones
+
+```yaml
+schema_version: "2.1"
+directory_name: milestone15
+description: "What this directory contains."
+title: "Milestone 15: The Representative Problem"   # experiment roots
+status: active                                      # active|completed|archived|falsified
+era: era4-milestone-stack-2026q2
+```
+
+`files:` and `child_directories:` are the **generated zone** — owned by
+`tools/update_meta_yamls.py`. Never hand-edit them; the updater round-trips the document
+and rewrites only that zone, so your authored fields survive.
+
+## Results are append-only
+
+`results/exp_NN_name_YYYYMMDD_HHMMSS.json`. The timestamp makes every run addressable and
+**nothing overwrites a prior run**. If you find yourself replacing a result file, stop —
+that is how a disagreeing earlier run disappears.
+
+## Scores are `N/M`, and hardening may lower them
+
+Put the score in the README as `Score: 34/40`. A test that passes for a reason unrelated
+to what it guards is tautological and gets **replaced, not counted** — which is why
+hardening cycles sometimes reduce a score. M11 went 52 → 49 → 52 and the dip was the
+process working. Never tune a test to pass.
+
+A failed experiment is a result. Record it; `theory/corrections.md` is a first-class
+artifact.
+
+## Pre-registration (STANDARDS §2.7)
+
+Before running: commit hypothesis, quantified thresholds, and the falsification condition.
+Commit outcomes separately, citing the registration hash. **Thresholds are never relaxed
+after seeing results.**
+
+**Register invariants, never absolute coordinates.** Registered relations survive;
+registered coordinates die. This rule came from Midnight and now governs the whole corpus
+— a prediction of "the peak sits at x = 4.2" is worthless where "the ratio of the two
+peaks is φ" is testable.
+
+## Silent-failure trap
+
+Two milestone1 scripts once built import paths as expressions, resolved them to
+directories that no longer existed, caught the `ImportError`, printed a warning, and
+**exited 0 with transcribed values** — a green run reporting numbers nothing had computed.
+If a script has a fallback path, make the fallback fail loudly. An undetected failure is
+itself a bug.
+
+## Before committing
+
+```bash
+python tools/validate_experiment_structure.py    # must print "No errors."
+```
+
+Then follow the `dft-repo-gates` skill for the regeneration order — the generators read
+the git index, so running them before `git add` produces files that fail CI.

--- a/.claude/skills/dft-lore-sync/SKILL.md
+++ b/.claude/skills/dft-lore-sync/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: dft-lore-sync
+description: Keep the Lore knowledge graph in sync after changing dawn-field-theory code, experiments, or structure. Use when moving or renaming experiments and documents, after a reorganization, or when updating an FDO or typed node — including the body-replacement and truncation traps.
+---
+
+# Vault sync — mandatory after structural change
+
+After any change that moves, renames, adds or removes experiments or documents, update the
+affected Lore nodes **in the same piece of work**. Vault drift is the top source of stale
+documentation, and a stale graph is worse than no graph because Bert answers from it.
+
+Search the graph *before* starting a topic, too: `lore_search(query, grade?)`. Trust grades:
+`curated`/`source` are authoritative, `reference` is useful but flagged for rebuild (the
+physics lives here), `legacy` is GRIM-era history.
+
+**kronos is retired. Never write through `kronos_*` tools.**
+
+## Two stores, two different fields
+
+This trips people up — a path change must be applied to whichever store holds it.
+
+| Store | Path field | Shape |
+|---|---|---|
+| **FDO** | `source_paths` | `[{repo, path, type}]`, `path` is repo-relative — no `dawn-field-theory/` prefix |
+| **Typed** | `slots.sources` | strings **with** the `dawn-field-theory/` prefix |
+
+Update FDO frontmatter with `lore_update(id, fields={...})`; update typed slots with
+`lore_update_slots`. Both merge — they do not replace the node.
+
+## The two traps that silently destroy content
+
+**1. `lore_update(body=...)` REPLACES the entire body.** There is no append mode. To edit a
+body you must have the whole current body first.
+
+**2. `lore_get` truncates bodies at 8KB.** So the obvious sequence — `lore_get`, edit the
+returned body, `lore_update(body=...)` — silently commits a truncated record for any node
+over 8KB.
+
+Fetch the full body over the HTTP API before writing one back:
+
+```
+GET  https://home.griminfra.com/bert/lore/api/fdo/{id}
+PUT  same endpoint
+```
+
+`milestone6-planning-seed` has a body of 8191 characters — one byte under the boundary.
+Do not assume a node is small enough.
+
+**If you only need to change frontmatter, use `fields=` and never send a body at all.**
+That is the safe path and avoids both traps entirely.
+
+## MCP calls to lore are sequential, never parallel
+
+Issue them one at a time. Parallel calls against the lore MCP face are unreliable here.
+
+Sessions also go stale after a container restart — reinitialize rather than retrying a
+failing call.
+
+## Verify the write actually landed
+
+Read the node back and check for a string you just wrote. A successful tool response is not
+proof the content is what you intended, especially after a body replacement.
+
+For a bulk migration, verify *every* path resolves on disk afterward rather than trusting
+the count of nodes updated.
+
+## Endpoints
+
+Lore runs on mesh-host CT106, `http://192.168.8.230:8103` (MCP at `/mcp`, mesh-bearer
+header required — the workspace `.mcp.json` carries it), and through the platform edge at
+`https://home.griminfra.com/bert/lore/api/`.
+
+The git mirrors `lore-vault/` (FDO) and `lore-vault-typed/` (typed) are **rendered
+mirrors**, committed by a 15-minute cron on CT106. Postgres is truth. A local mirror clone
+that looks stale is usually just unpulled — check `git fetch && git status -sb` before
+concluding the sync is broken.

--- a/.claude/skills/dft-publish-integrity/SKILL.md
+++ b/.claude/skills/dft-publish-integrity/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: dft-publish-integrity
+description: Rules for anything under papers/ in dawn-field-theory — published packages, DOIs, and citation metadata. Use before editing, moving, reformatting or repackaging any paper, running a repo-wide sweep that could touch papers/, or answering a question about which DOI to cite.
+---
+
+# Published packages are frozen
+
+**A DOI points at a snapshot. If the snapshot changes, the DOI stops being reproducible.**
+
+Anything under `papers/` carrying a DOI is a frozen artifact: never edited, never
+reformatted, never retrofitted to current repository standards — even when the current
+standard says otherwise.
+
+This has been violated twice and both times had to be reverted:
+
+- A repo-wide reference sweep rewrote links inside **113 files** in DOI-bearing packages.
+- A `meta.yaml` cleanup removed **62 files** from inside published packages, because the
+  rule it applied ("meta.yaml at experiment roots only") does not scope to papers at all.
+
+Before any bulk operation, exclude `papers/`. After any bulk operation, verify:
+
+```bash
+# papers/ must be byte-identical to its last published state
+git diff --stat main..HEAD -- papers/
+```
+
+## Three consequences that look like inconsistencies
+
+They all follow from the freeze rule. Do not "fix" them:
+
+- `series/PACSeries/v0.1` declares itself superseded by v0.2 and would otherwise belong in
+  `archive/` — it stays, because a reader following its DOI must find it here.
+- Package `meta.yaml` files survived the repo-wide removal of 429 others.
+- `UNIFIED_EVIDENCE.md` exists in 20 copies across 5 drifted versions. Reconciling them
+  would mean editing published packages. The divergence is recorded in `papers/README.md`
+  instead.
+
+## Corrections go forward, never backward
+
+When published content is wrong, the correction goes into `theory/corrections.md` and the
+next version. Never into the frozen package. Superseded work is **lineage**: a result that
+was later reframed is only legible against what it replaced.
+
+## Two Zenodo record families — do not conflate them
+
+Verified against the Zenodo API 2026-08-10:
+
+| | Concept DOI | Latest version |
+|---|---|---|
+| **PACSeries** — the papers | `10.5281/zenodo.17295102` | v0.3 = `…21228036` (2026-07-06) |
+| **Repository archive** — this repo as software | `10.5281/zenodo.15595182` | v1.0_prerelease = `…15783623` (2025-07-01) |
+
+- Citing the **papers** → PACSeries concept DOI. This is what `README.md` advertises.
+- Citing the **repository** → `CITATION.cff`, which carries the repo-archive concept DOI.
+
+**Always cite a concept DOI, never a version DOI.** A concept DOI resolves forward to the
+newest version; `CITATION.cff` previously carried `15783623`, a *version* DOI, which pinned
+every citation of the repository to a July 2025 snapshot.
+
+`CITATION.cff` is not modified without verifying against Zenodo first.
+
+## `registry/` is the source of truth
+
+For publication status, DOIs and provenance, read `papers/registry/` — not the per-package
+documents, which disagree with it in places.
+
+`status: needs_repackage` means the **source** moved ahead of the **uploaded artifact**
+(v1.2 source vs v1.1/v2.1 packaged). Repackaging cuts a new DOI version, and production
+publishing is TTY-CLI only per ADR-0029 — it is not an agent action.

--- a/.claude/skills/dft-repo-gates/SKILL.md
+++ b/.claude/skills/dft-repo-gates/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: dft-repo-gates
+description: Run the dawn-field-theory CI gates and regenerate generated artifacts in the correct order. Use before committing or opening a PR in this repo, or when CI reports a generated file is stale, link rot grew, or the structure validator failed.
+---
+
+# The repository gates
+
+CI (`.github/workflows/repo-standards.yml`) verifies; it never writes to the repo. Four
+gates, all runnable locally.
+
+```bash
+python tools/validate_experiment_structure.py      # STANDARDS §2/§5
+python tools/generate_experiment_index.py --check  # experiments/EXPERIMENTS.md
+python tools/generate_inventory.py --check         # INVENTORY.md
+python tools/check_links.py --max 201              # link rot ceiling
+```
+
+Plus a freshness check that regenerates `map.yaml` and the `meta.yaml` generated zone and
+fails if anything differs.
+
+## The ordering trap — read this before regenerating
+
+**The generators read `git ls-files`. They must run AFTER `git add`.**
+
+Run them on unstaged work and they silently undercount new files. The result looks correct
+locally, passes `--check` on the *next* run, and fails CI with no visible cause. This
+happened: two new layer READMEs were missed, `INVENTORY.md` recorded `theory/` as 15 files
+instead of 16, and it cost a CI round-trip to find.
+
+Correct order — stage first, regenerate, stage again:
+
+```bash
+git add -A
+python tools/update_meta_yamls.py
+python tools/generate_path.py
+python tools/generate_inventory.py
+python tools/generate_experiment_index.py
+git add -A
+git diff --quiet && echo "converged"      # must be clean
+```
+
+Adding a file can change `map.yaml` and a `meta.yaml`, which is why the second `git add`
+matters. `generate_inventory.py` warns when untracked files sit in counted layers — heed it.
+
+## Generated files are never hand-edited
+
+`map.yaml`, `experiments/EXPERIMENTS.md`, `INVENTORY.md`, and the `files` /
+`child_directories` keys of any `meta.yaml`. Editing them by hand produces a diff CI
+immediately reverts you on.
+
+## Link rot is ceilinged, not fixed
+
+`check_links.py --max 201` — the count may **fall, never rise**. The repo carries known rot
+inside archived documents; the gate exists to stop new rot, not to force old cleanup. If a
+change deliberately raises the count, raise the ceiling in the workflow *in the same
+commit* and say why.
+
+`.changelog/` is excluded by default: a changelog is a dated record of what was true when
+written, so a path that has since moved is correct history.
+
+## Reading git from a tool: two rules
+
+Both of these caused real bugs here.
+
+1. **Decode as UTF-8 explicitly.** `subprocess.run(..., text=True)` uses the locale codec —
+   cp1252 on Windows — which mangles non-ASCII paths. The link checker then looked for a
+   file that did not exist under the mangled name, skipped it, and disagreed with CI by
+   exactly one link. Use `capture_output=True` and `.stdout.decode("utf-8", "surrogateescape")`.
+2. **Enumerate from git, not the filesystem.** `generate_path.py` once walked the disk and
+   swept the gitignored 600 MB `internal/` tree — containing private material — into
+   `map.yaml`, a file committed to a **public** repo. Use `git ls-files -z`.
+
+## When a gate fails
+
+`--check` gates print a unified diff of committed vs regenerated. Read it — it names the
+drift. If the diff is only counts, you hit the ordering trap above.

--- a/.gitignore
+++ b/.gitignore
@@ -141,8 +141,13 @@ cimm.log
 # Ignore internal workspace directory
 /internal/
 
-# Claude local settings
-.claude/
+# Claude local settings stay local; the shared agent skills travel with the repo.
+# Order matters: git will not descend into an excluded directory, so `.claude` must be
+# un-excluded first (it is also caught by `*.claude` above) before anything inside it
+# can be re-included.
+!.claude/
+.claude/*
+!.claude/skills/
 
 # Session research notes
 SESSION_NOTES.md

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -15,7 +15,7 @@ The whole corpus at a glance. Per-experiment detail is in [`experiments/EXPERIME
 | [`archive/`](archive/) | lineage, by era — terminal | 5121 |
 | [`tools/`](tools/) | generators and validators | 11 |
 
-Tracked files: **9368**
+Tracked files: **9372**
 
 **75 experiments** — 50 live, 25 archived. Plus 2 spikes, exempt from the experiment standard (STANDARDS.md §3).
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -22,6 +22,15 @@ both referenced `STANDARDS.md` as the canonical spec, but no such file existed. 
 absence three mutually incompatible `meta.yaml` specs and two overlapping journal specs
 grew up, and nothing validated any of them.
 
+### Why a workspace-wide document lives in this repository
+
+`core_workspace/` is **not a git repo**, so a copy at the workspace root would be
+untracked, unbacked-up, and free to drift from any tracked copy. The canonical copy
+therefore lives here, at `dawn-field-theory/STANDARDS.md`, where it is version-controlled
+and public. Everything that references it — the workspace `CLAUDE.md`,
+`.claude/instructions/main.instructions.md`, and per-repo `CLAUDE.md` files — points at
+that path. **There is exactly one copy; do not create a second.**
+
 ---
 
 ## 1. Workspace layout
@@ -372,10 +381,45 @@ points back via `source_paths`. Both sides are checked (§9).
 | Corpus inventory freshness | `tools/generate_inventory.py` |
 | Repo tree map | `tools/generate_path.py` → `map.yaml` |
 | meta.yaml generated zone | `tools/update_meta_yamls.py` |
-| Internal link integrity | *(no working tool — `tools/link_checker.py` is dead: it hardcodes an absolute path to a directory that does not exist)* |
+| Internal link integrity | `tools/check_links.py` — ceilinged in CI (`--max`), so rot may fall but not rise |
 | Citations | `tools/validate_citations.py` |
-| FDO `source_paths` resolve | `/fdo-source-validate` |
+| FDO `source_paths` resolve | see the `dft-lore-sync` skill (§10) |
 
-Structure, index, and map checks run in CI on push. A standards violation is a CI failure,
-not a style note — that is the mechanism preventing the drift this document was written to
-end.
+`tools/link_checker.py` is superseded by `check_links.py` and is dead — it hardcodes an
+absolute path to a directory that does not exist. It survives only because nothing has
+deleted it yet.
+
+Structure, index, map, and link checks run in CI on push. A standards violation is a CI
+failure, not a style note — that is the mechanism preventing the drift this document was
+written to end.
+
+---
+
+## 10. Agent skills
+
+The conventions in this document are only worth writing if something hands them to whoever
+is doing the work. Skills are that delivery mechanism.
+
+They live in `dawn-field-theory/.claude/skills/<name>/SKILL.md` and are **tracked**, so
+they travel with the repository. `.gitignore` excludes `.claude/` (local settings) with an
+explicit `!.claude/skills/` exception; git will not descend into an excluded directory, so
+that exception has to un-exclude `.claude` itself before it can re-include `skills`.
+
+| Skill | Covers |
+|---|---|
+| `dft-experiment` | experiment structure, meta.yaml zones, scoring, pre-registration |
+| `dft-repo-gates` | the CI gates and the regeneration order |
+| `dft-lore-sync` | vault sync, and the body-replacement / 8KB-truncation traps |
+| `dft-publish-integrity` | frozen packages, DOIs, which record family to cite |
+
+### The rule for writing one
+
+**A skill states the rule, the failure it prevents, and the command that verifies it.**
+Prose that restates this document is not a skill — an agent already has this document. What
+it does not have is the knowledge that `INVENTORY.md` will silently undercount if the
+generators run before `git add`, or that `lore_get` truncates at 8KB and `milestone6-planning-seed`
+sits one byte under that boundary. Earn the content from a failure that actually happened.
+
+This replaces the previous mechanism. The 35 slash commands under
+`core_workspace/.claude/commands/` all loaded their protocol through
+`mcp__kronos__kronos_skill_load`, and kronos is retired — every one was a dead pointer.

--- a/map.yaml
+++ b/map.yaml
@@ -48,6 +48,16 @@ dawn-field-theory/
     20260810_004500_repo_reorg_standardization.md
     20260810_120000_layer_reorganization.md
     README.md
+  .claude/
+    skills/
+      dft-experiment/
+        SKILL.md
+      dft-lore-sync/
+        SKILL.md
+      dft-publish-integrity/
+        SKILL.md
+      dft-repo-gates/
+        SKILL.md
   .github/
     pull_request_template.md
     workflows/

--- a/meta.yaml
+++ b/meta.yaml
@@ -33,6 +33,7 @@ files:
 - timeline.md
 child_directories:
 - .changelog
+- .claude
 - .github
 - archive
 - experiments


### PR DESCRIPTION
The conventions were written but nothing delivered them.

All **35** slash commands in `core_workspace/.claude/commands/` loaded their protocol through `mcp__kronos__kronos_skill_load()`, and **kronos is retired** — every one was a dead pointer, and none referenced lore. So the standard existed (`STANDARDS.md`, a validator, four CI gates) while nothing handed it to whoever was doing the work. That is why agents were not "automatically being faithful to all this stuff": the delivery mechanism died and nothing replaced it.

## Four skills, earned from real failures

Each states the rule, the failure it prevents, and the command that verifies it — not prose restating `STANDARDS.md`, which an agent already has.

| Skill | Earned from |
|---|---|
| `dft-experiment` | the silent-fallback imports that resolved to vanished directories, warned, and **exited 0 with transcribed values** |
| `dft-repo-gates` | generators read `git ls-files`, so running them before `git add` undercounts silently — `INVENTORY.md` recorded `theory/` as 15 files instead of 16 and failed CI with no visible cause |
| `dft-lore-sync` | `lore_update(body=)` REPLACES and `lore_get` truncates at 8KB; `milestone6-planning-seed` is 8191 chars — one byte under the boundary |
| `dft-publish-integrity` | 113 content files and 62 `meta.yaml` had to be restored after bulk operations edited them inside DOI-bearing packages |

## Skills are tracked

`.gitignore` excluded `.claude/` for local settings. Git will not descend into an excluded directory, so a naive `!.claude/skills/` would have silently done nothing — the exception un-excludes `.claude` first, then re-includes `skills`. Verified both ways: 4 skill files tracked, `settings.json` still ignored.

## STANDARDS.md

- New **§10 Agent skills** — where they live, and the rule that a skill must name the failure it prevents.
- **Scope** now explains why a workspace-wide document lives in this repo: `core_workspace/` is not a git repo, so a root copy would be untracked and free to drift. Exactly one copy exists.
- **§9** now lists `tools/check_links.py`, which exists, instead of claiming there is no working link tool, and no longer points at `/fdo-source-validate` (deleted).

## Outside this repo (untracked workspace, no PR)

- Deleted the 35 dead commands; `.claude/commands/` is now empty by design.
- Workspace `CLAUDE.md` and `.claude/instructions/main.instructions.md` pointed at a root `STANDARDS.md` that no longer exists — reintroducing the exact gap STANDARDS.md was written to close. Both now point at `dawn-field-theory/STANDARDS.md`, and the instruction file's command table is replaced with the live repo + lore skills.
- `.claude/README.md` documented the deleted surface (and said 28 where there were 35).

Gates green: validator 0 errors, both indexes current, link count 201 at ceiling.
